### PR TITLE
fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
-  "repository": "git://github.com/vlaraort/addon-screen-reader.git",
+  "repository": "git+https://github.com/vlaraort/addon-screen-reader.git",
   "files": [
     "dist/**/*",
     "README.md",


### PR DESCRIPTION
## Summary

- update the package repository URL from the unauthenticated `git://` protocol to `git+https`

## Validation

- checked `package.json` parses and points to `git+https://github.com/vlaraort/addon-screen-reader.git`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
